### PR TITLE
Add missing strudel manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # mus_data
+
+This repository contains audio samples used for development and testing.
+
+## Data Files
+
+All audio files are stored in the `data/` directory. A JSON manifest named
+`data/strudel.json` lists the available samples. The file can be downloaded from
+GitHub using the raw URL:
+
+```
+https://raw.githubusercontent.com/Grossculptor/mus_data/main/data/strudel.json
+```
+

--- a/data/strudel.json
+++ b/data/strudel.json
@@ -1,0 +1,10 @@
+{
+  "samples": [
+    "data.wav",
+    "data_1.wav",
+    "data_2.wav",
+    "data_3.wav",
+    "data_4.wav",
+    "data_5.wav"
+  ]
+}


### PR DESCRIPTION
## Summary
- add `strudel.json` manifest listing audio samples
- document manifest location and download URL in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e930661d88320a6fcebe35290a405